### PR TITLE
fix: update API endpoint for fetching course slug in enrollment service

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,10 @@ const nextConfig: NextConfig = {
     async rewrites() {
         return [
             {
+                source: "/api/v1/:path*",
+                destination: `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1"}/:path*`,
+            },
+            {
                 source: "/api/:path*",
                 destination: `${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1"}/:path*`,
             }

--- a/services/enrollmentService.ts
+++ b/services/enrollmentService.ts
@@ -83,7 +83,7 @@ export const getUserEnrollments = async (
                 if (!enrollment.courseSlug && enrollment.courseId) {
                     try {
                         // Lấy slug từ API nếu chưa có
-                        const courseResponse = await apiClient.get(`/courses/slug/${enrollment.courseId}`);
+                        const courseResponse = await apiClient.get(`/courses/by-id/${enrollment.courseId}`);
                         return {
                             ...enrollment,
                             courseSlug: courseResponse.data.data.slug


### PR DESCRIPTION
This pull request introduces a new API rewrite rule and updates an API endpoint used to fetch course slugs by course ID. These changes improve the routing and data-fetching logic in the application.

**Routing improvements:**
* Added a new rewrite rule in `next.config.ts` to route requests from `/api/v1/:path*` to the backend API, using the `NEXT_PUBLIC_API_URL` environment variable or defaulting to `http://localhost:8080/api/v1` if not set.

**API integration updates:**
* Updated the endpoint in `enrollmentService.ts` when fetching a course slug by course ID, changing it from `/courses/slug/:id` to `/courses/by-id/:id` for improved clarity and consistency with backend routes.