### PR TITLE
feat: enhance CI pipeline with detailed linting and type checking steps

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -6,15 +6,28 @@ on:
 
 jobs:
   lint-and-typecheck:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '20.13.1'
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run typecheck
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
 
   build-app:
     name: Build Application


### PR DESCRIPTION
This pull request updates the `lint-and-typecheck` job in the `.github/workflows/ci-cd-dev.yml` workflow to improve clarity, caching, and reproducibility. The main changes include adding step names, enabling npm caching, and using more explicit commands for type checking.

Enhancements to CI workflow steps:

* Added descriptive `name` fields for each step in the `lint-and-typecheck` job to improve readability and traceability in CI logs.
* Enabled npm caching in the `setup-node` step to speed up dependency installation.
* Set `fetch-depth: 0` in the `checkout` step to ensure the full git history is available for CI tasks.
* Replaced `npm run typecheck` with `npx tsc --noEmit` for more explicit TypeScript type checking.