### PR TITLE
fix: update deployment script for Docker Compose configuration

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -91,12 +91,12 @@ jobs:
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
+          password: ${{ secrets.VPS_PASSWORD }}
           port: ${{ secrets.VPS_PORT || 22 }}
           script: |
-            cd /home/${{ secrets.VPS_USER }}/ms-ci-cd
-            sudo docker compose -f docker-compose.dev.yml pull vinaacademy-frontend
-            sudo docker compose -f docker-compose.dev.yml up -d vinaacademy-frontend
+            cd /${{ secrets.VPS_USER }}/ms-ci-cd
+            sudo docker compose -f services/docker-compose.yml pull vinaacademy-frontend
+            sudo docker compose -f services/docker-compose.yml --env-file .env.services up -d vinaacademy-frontend
             sudo docker image prune -f
             sleep 10
-            sudo docker compose -f docker-compose.dev.yml ps vinaacademy-frontend
+            sudo docker compose -f services/docker-compose.yml ps vinaacademy-frontend


### PR DESCRIPTION
This pull request updates the deployment workflow configuration in `.github/workflows/ci-cd-dev.yml` to improve deployment reliability and align with recent changes to the project structure. The main changes involve switching authentication methods, updating deployment paths, and enhancing Docker Compose commands.

**Deployment workflow updates:**

* Changed SSH authentication from using a private key to using a password, by replacing the `key` with `password` in the workflow secrets.
* Updated the deployment directory from `/home/${{ secrets.VPS_USER }}/ms-ci-cd` to `/${{ secrets.VPS_USER }}/ms-ci-cd` to match the current server structure.
* Changed Docker Compose file path from `docker-compose.dev.yml` to `services/docker-compose.yml`, reflecting the new location and naming convention.
* Added the `--env-file .env.services` flag to the Docker Compose up command to ensure the correct environment variables are used during deployment.
* Updated all related Docker Compose commands to use the new file path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration with improvements to deployment infrastructure, authentication methods, and service management settings.
  * Enhanced deployment path handling and environment configuration for improved deployment workflow reliability.
  * Refined service orchestration and configuration management to optimize the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->