### PR TITLE
fix: correct quizId parameter naming in createQuiz function

### DIFF
--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -12,7 +12,7 @@ export async function createQuiz(
   try {
     const response: AxiosResponse = await apiClient.post(
       API_ENDPOINTS.AI.GENERATE_QUIZ,
-      { prompt, quizId },
+      { prompt, quiz_id: quizId },
     )
     return response.data['data']
   } catch (error) {


### PR DESCRIPTION
This pull request makes a minor update to the request payload in the `createQuiz` function of `aiService.ts`. Specifically, it changes the property name sent to the backend from `quizId` to `quiz_id` to ensure proper API compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where quiz creation was not functioning correctly due to incorrect data format being sent to the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->