### PR TITLE
Update chatbotService to use hardcoded API URL for chatbot stream

### DIFF
--- a/services/chatbotService.ts
+++ b/services/chatbotService.ts
@@ -90,7 +90,7 @@ export const chatbotService = {
       }
 
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}${API_ENDPOINTS.CHATBOT.CHAT_STREAM}`,
+        `${'https://api.vnacademy.io.vn/api/v1'}${API_ENDPOINTS.CHATBOT.CHAT_STREAM}`,
         {
           method: 'POST',
           headers: headers,


### PR DESCRIPTION
This pull request makes a small but important change to the `chatbotService` by updating the API base URL to a hardcoded value instead of relying on the environment variable.

* Changed the API base URL in the `chatbotService` to use a hardcoded URL (`https://api.vnacademy.io.vn/api/v1`) instead of `process.env.NEXT_PUBLIC_API_URL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated chat service connection configuration to improve reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->