### PR TITLE
feat: add enrollment check and handle duplicate course addition in AddToCartPage

### DIFF
--- a/app/(student)/courses/[slug]/checkout/page.tsx
+++ b/app/(student)/courses/[slug]/checkout/page.tsx
@@ -96,6 +96,7 @@ export default function AddToCartPage({
     isAuthLoading,
     isAuthenticated,
     isInitialized,
+    cartItems,
   ])
 
   return (

--- a/app/(student)/courses/[slug]/checkout/page.tsx
+++ b/app/(student)/courses/[slug]/checkout/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/context/AuthContext'
 import { Loader2 } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { getCourseBySlug } from '@/services/courseService'
+import { checkEnrollment } from '@/services/enrollmentService'
 
 export default function AddToCartPage({
   params,
@@ -14,7 +15,7 @@ export default function AddToCartPage({
   params: Promise<{ slug: string }>
 }) {
   const router = useRouter()
-  const { addToCart, isInitialized } = useCart()
+  const { addToCart, isInitialized, cartItems } = useCart()
   const { isAuthenticated, isLoading: isAuthLoading } = useAuth()
   const { toast } = useToast()
   const [status, setStatus] = useState<'loading' | 'error' | 'success'>(
@@ -42,6 +43,24 @@ export default function AddToCartPage({
         if (!course) {
           setStatus('error')
           router.push('/cart')
+          return
+        }
+
+        const isEnrolled = await checkEnrollment(course.id)
+        if (isEnrolled) {
+          toast({
+            title: 'Lỗi',
+            description: 'Bạn đã đăng ký khóa học này rồi',
+            variant: 'destructive',
+          })
+          setStatus('error')
+          router.push(`/courses/${slug}`)
+          return
+        }
+        const isInCart = cartItems.some((item) => item.courseId === course.id)
+        if (isInCart) {
+          router.push('/cart')
+          setStatus('success')
           return
         }
 


### PR DESCRIPTION
This pull request updates the course checkout page logic to improve the user experience when adding a course to the cart. The main changes ensure that users cannot add a course they are already enrolled in or that is already in their cart, providing appropriate feedback and navigation.

**Checkout validation improvements:**

* Added a check using `checkEnrollment` to prevent users from adding a course they are already enrolled in, displaying an error toast and redirecting them to the course page if necessary. ([app/(student)/courses/[slug]/checkout/page.tsxR49-R66](diffhunk://#diff-2823e510668d27758cc4dbb36a6907923be2b545cb0c5aac993b3e97f8b1f73dR49-R66))
* Added a check to see if the course is already in the user's cart (`cartItems`), redirecting them to the cart page instead of adding the course again. ([app/(student)/courses/[slug]/checkout/page.tsxR49-R66](diffhunk://#diff-2823e510668d27758cc4dbb36a6907923be2b545cb0c5aac993b3e97f8b1f73dR49-R66))

**Code updates:**

* Imported `checkEnrollment` from `@/services/enrollmentService` and included `cartItems` from `useCart` to support the new validation logic. ([app/(student)/courses/[slug]/checkout/page.tsxR10-R18](diffhunk://#diff-2823e510668d27758cc4dbb36a6907923be2b545cb0c5aac993b3e97f8b1f73dR10-R18))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrollment validation in checkout: users who are already enrolled are shown a warning and redirected to the course page.
  * Cart duplicate detection: courses already in your cart redirect you to the cart page instead of being added again.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->