### PR TITLE
fix: correct sorting order for unauthenticated users in course recommendations

### DIFF
--- a/components/layout/home/LearningRecommendations.tsx
+++ b/components/layout/home/LearningRecommendations.tsx
@@ -15,7 +15,7 @@ const LearningRecommendations = () => {
   // Fetch courses from API
   const { courses, loading, error } = useCourses({
     minRating: 3.5,
-    sortBy: isAuthenticated ? 'rating' : ['totalStudent,desc', 'rating,desc'],
+    sortBy: isAuthenticated ? 'rating' : ['totalStudent,asc', 'rating,desc'],
     sortDirection: 'desc',
     size: 8,
   })


### PR DESCRIPTION
This pull request makes a small change to the sorting logic for recommended courses in the `LearningRecommendations` component. For unauthenticated users, the courses are now sorted by ascending `totalStudent` count, then by descending rating, instead of descending `totalStudent` count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted course sorting order for unauthenticated users to display courses with fewer enrolled students first while maintaining rating-based relevance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->